### PR TITLE
Refactored to change pymatgen.io.jdftx module import names

### DIFF
--- a/src/atomate2/jdftx/schemas/calculation.py
+++ b/src/atomate2/jdftx/schemas/calculation.py
@@ -8,8 +8,8 @@ from typing import Optional, Union
 
 from pydantic import BaseModel, Field
 from pymatgen.core.structure import Structure
-from pymatgen.io.jdftx.jdftxinfile import JDFTXInfile
-from pymatgen.io.jdftx.jdftxoutfile import JDFTXOutfile
+from pymatgen.io.jdftx.inputs import JDFTXInfile
+from pymatgen.io.jdftx.outputs import JDFTXOutfile
 
 from atomate2.jdftx.schemas.enums import TaskType
 
@@ -25,7 +25,7 @@ class CalculationInput(BaseModel):
     # Waiting on parsers to be finished.
 
     structure: Structure = Field(
-        None, description="input structure to JDFTx calcualtion"
+        None, description="input structure to JDFTx calculation"
     )
 
     parameters: dict = Field(None, description="input tags in JDFTx in file")

--- a/src/atomate2/jdftx/sets/BaseJdftxSet.yaml
+++ b/src/atomate2/jdftx/sets/BaseJdftxSet.yaml
@@ -48,34 +48,6 @@ symmetries: none
 ### Pseudopotential ###
 ion-species: GBRV_v1.5/$ID_pbe_v1.uspp
 
-# ### Output Files ###
-# dump-name: jdftx.$VAR
-# dump:
-#   - freq: End
-#     var: Dtot
-#   - freq: End
-#     var: BoundCharge
-#   - freq: End
-#     var: State
-#   - freq: End
-#     var: Forces
-#   - freq: End
-#     var: Ecomponents
-#   - freq: End
-#     var: VfluidTot
-#   - freq: End
-#     var: ElecDensity
-#   - freq: End
-#     var: KEdensity
-#   - freq: End
-#     var: EigStats
-#   - freq: End
-#     var: BandEigs
-#   - freq: End
-#     var: bandProjections
-#   - freq: End
-#     var: DOS
-
 
 ### Output Files ###
 dump-name: jdftx.$VAR
@@ -83,3 +55,13 @@ dump:
   - End:
       Dtot: True
       State: True
+      BoundCharge: True
+      Forces: True
+      Ecomponents: True
+      VfluidTot: True
+      ElecDensity: True
+      KEdensity: True
+      EigStats: True
+      BandEigs: True
+      bandProjections: True
+      DOS: True

--- a/src/atomate2/jdftx/sets/base.py
+++ b/src/atomate2/jdftx/sets/base.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any
 
 from monty.serialization import loadfn
 from pymatgen.io.core import InputGenerator, InputSet
-from pymatgen.io.jdftx.jdftxinfile import JDFTXInfile, JDFTXStructure
+from pymatgen.io.jdftx.inputs import JDFTXInfile, JDFTXStructure
 
 if TYPE_CHECKING:
     from pymatgen.core import Structure
@@ -59,11 +59,10 @@ class JdftxInputSet(InputSet):
 
         if not overwrite and (directory / infile).exists():
             raise FileExistsError(f"{directory / infile} already exists.")
-        print(directory)
+
         jdftxinput = condense_jdftxinputs(self.jdftxinput, self.jdftxstructure)
 
         jdftxinput.write_file(filename=(directory / infile))
-        print(f"Wrote JDFTx input file to {directory / infile}")
 
     @staticmethod
     def from_directory(
@@ -121,7 +120,6 @@ class JdftxInputGenerator(InputGenerator):
         """
         jdftx_structure = JDFTXStructure(structure)
         jdftxinputs = self.settings
-        print(jdftxinputs)
         jdftxinput = JDFTXInfile.from_dict(jdftxinputs)
 
         return JdftxInputSet(jdftxinput=jdftxinput, jdftxstructure=jdftx_structure)
@@ -131,9 +129,11 @@ def condense_jdftxinputs(
     jdftxinput: JDFTXInfile, jdftxstructure: JDFTXStructure
 ) -> JDFTXInfile:
     """
-    Function to combine a JDFTXInputs class with calculation
+    Combine JDFTXInfile and JDFTxStructure into complete JDFTXInfile.
+
+    Function combines a JDFTXInfile class with calculation
     settings and a JDFTxStructure that defines the structure
-    into one JDFTXInputs instance.
+    into one JDFTXInfile instance.
 
     Parameters
     ----------
@@ -149,5 +149,4 @@ def condense_jdftxinputs(
             A JDFTXInfile that includes the calculation
             parameters and input structure.
     """
-    condensed_inputs = jdftxinput + JDFTXInfile.from_str(jdftxstructure.get_str())
-    return condensed_inputs
+    return jdftxinput + JDFTXInfile.from_str(jdftxstructure.get_str())


### PR DESCRIPTION
@benrich37 changed the pymatgen module names to `pymatgen.io.jdftx.inputs` and `pymatgen.io.jdftx.outputs`. These module name changes were incorporated in all the import spots