### PR TITLE
Tests refactor

### DIFF
--- a/src/atomate2/jdftx/schemas/calculation.py
+++ b/src/atomate2/jdftx/schemas/calculation.py
@@ -227,7 +227,7 @@ class Calculation(BaseModel):
         jdftxoutput_file: Union[Path, str],
         jdftxinput_kwargs: Optional[dict] = None,
         jdftxoutput_kwargs: Optional[dict] = None,
-        # task_name  # do we need task names? These are created by Custodian
+        # **jdftx_calculation_kwargs, #TODO implement optional calcdoc kwargs
     ) -> "Calculation":
         """
         Create a JDFTx calculation document from a directory and file paths.

--- a/src/atomate2/jdftx/schemas/task.py
+++ b/src/atomate2/jdftx/schemas/task.py
@@ -81,7 +81,7 @@ class TaskDoc(StructureMetadata):
         cls: type[_T],
         dir_name: Union[Path, str],
         additional_fields: dict[str, Any] = None,
-        **jdftx_calculation_kwargs,
+        # **jdftx_calculation_kwargs, #TODO implement
     ) -> Self:
         """
         Create a task document from a directory containing JDFTx files.
@@ -94,7 +94,7 @@ class TaskDoc(StructureMetadata):
             Whether to store additional json files in the calculation directory.
         additional_fields
             dictionary of additional fields to add to output document.
-        **qchem_calculation_kwargs
+        **jdftx_calculation_kwargs
             Additional parsing options that will be passed to the
             :obj:`.Calculation.from_qchem_files` function.
 
@@ -111,7 +111,7 @@ class TaskDoc(StructureMetadata):
             dir_name=dir_name,
             jdftxinput_file=FILE_NAMES["in"],
             jdftxoutput_file=FILE_NAMES["out"],
-            **jdftx_calculation_kwargs,
+            # **jdftx_calculation_kwargs, # still need to implement
         )
 
         doc = cls.from_structure(

--- a/src/atomate2/jdftx/sets/base.py
+++ b/src/atomate2/jdftx/sets/base.py
@@ -176,9 +176,6 @@ class JdftxInputGenerator(InputGenerator):
         jdftxinputs = self.settings
         jdftxinput = JDFTXInfile.from_dict(jdftxinputs)
 
-        jdftxinputs = self.settings
-        jdftxinput = JDFTXInfile.from_dict(jdftxinputs)
-
         return JdftxInputSet(jdftxinput=jdftxinput, jdftxstructure=jdftx_structure)
 
     def set_kgrid(self, structure: Structure) -> Kpoint:

--- a/src/atomate2/jdftx/sets/base.py
+++ b/src/atomate2/jdftx/sets/base.py
@@ -174,7 +174,6 @@ class JdftxInputGenerator(InputGenerator):
 
         jdftx_structure = JDFTXStructure(structure)
         jdftxinputs = self.settings
-        jdftxinputs["coords-type"] = "Cartesian"  # always force Cartesian
         jdftxinput = JDFTXInfile.from_dict(jdftxinputs)
 
         jdftxinputs = self.settings

--- a/tests/jdftx/conftest.py
+++ b/tests/jdftx/conftest.py
@@ -36,15 +36,6 @@ def jdftx_test_dir(test_dir):
     return test_dir / "jdftx"
 
 
-@pytest.fixture
-def mock_cwd(monkeypatch, request):
-    test_name = request.param
-    mock_path = (
-        Path(__file__).resolve().parent / f"../test_data/jdftx/{test_name}"
-    ).resolve()
-    monkeypatch.setattr(os, "getcwd", lambda: str(mock_path))
-
-
 @pytest.fixture(params=["sp_test", "ionicmin_test", "latticemin_test"])
 def task_name(request):
     task_table = {
@@ -57,8 +48,8 @@ def task_name(request):
 
 @pytest.fixture
 def mock_filenames(monkeypatch):
-    monkeypatch.setitem(FILE_NAMES, "in", "inputs/init.in")
-    monkeypatch.setitem(FILE_NAMES, "out", "outputs/jdftx.out")
+    monkeypatch.setitem(FILE_NAMES, "in", "init.in")
+    monkeypatch.setitem(FILE_NAMES, "out", "jdftx.out")
 
 
 @pytest.fixture
@@ -164,7 +155,9 @@ def clear_jdftx_inputs():
 
 
 def copy_jdftx_outputs(ref_path: Path):
+    base_path = Path(os.getcwd())
     output_path = ref_path / "outputs"
+    logger.info(f"copied output files to {base_path}")
     for output_file in output_path.iterdir():
         if output_file.is_file():
             shutil.copy(output_file, ".")

--- a/tests/jdftx/jobs/test_core.py
+++ b/tests/jdftx/jobs/test_core.py
@@ -1,4 +1,3 @@
-import pytest
 from jobflow import run_locally
 
 from atomate2.jdftx.jobs.core import IonicMinMaker, LatticeMinMaker, SinglePointMaker
@@ -10,8 +9,7 @@ from atomate2.jdftx.sets.core import (
 )
 
 
-@pytest.mark.parametrize("mock_cwd", ["sp_test"], indirect=True)
-def test_sp_maker(mock_jdftx, si_structure, mock_cwd, mock_filenames, clean_dir):
+def test_sp_maker(mock_jdftx, si_structure, mock_filenames, clean_dir):
     ref_paths = {"single_point": "sp_test"}
 
     fake_run_jdftx_kwargs = {}
@@ -19,6 +17,7 @@ def test_sp_maker(mock_jdftx, si_structure, mock_cwd, mock_filenames, clean_dir)
     mock_jdftx(ref_paths, fake_run_jdftx_kwargs)
 
     maker = SinglePointMaker(input_set_generator=SinglePointSetGenerator())
+    maker.input_set_generator.user_settings["coords-type"] = "Lattice"
 
     job = maker.make(si_structure)
 
@@ -27,8 +26,7 @@ def test_sp_maker(mock_jdftx, si_structure, mock_cwd, mock_filenames, clean_dir)
     assert isinstance(output1, TaskDoc)
 
 
-@pytest.mark.parametrize("mock_cwd", ["ionicmin_test"], indirect=True)
-def test_ionicmin_maker(mock_jdftx, si_structure, mock_cwd, mock_filenames, clean_dir):
+def test_ionicmin_maker(mock_jdftx, si_structure, mock_filenames, clean_dir):
     ref_paths = {"ionic_min": "ionicmin_test"}
 
     fake_run_jdftx_kwargs = {}
@@ -36,6 +34,7 @@ def test_ionicmin_maker(mock_jdftx, si_structure, mock_cwd, mock_filenames, clea
     mock_jdftx(ref_paths, fake_run_jdftx_kwargs)
 
     maker = IonicMinMaker(input_set_generator=IonicMinSetGenerator())
+    maker.input_set_generator.user_settings["coords-type"] = "Lattice"
 
     job = maker.make(si_structure)
 
@@ -44,10 +43,7 @@ def test_ionicmin_maker(mock_jdftx, si_structure, mock_cwd, mock_filenames, clea
     assert isinstance(output1, TaskDoc)
 
 
-@pytest.mark.parametrize("mock_cwd", ["latticemin_test"], indirect=True)
-def test_latticemin_maker(
-    mock_jdftx, si_structure, mock_cwd, mock_filenames, clean_dir
-):
+def test_latticemin_maker(mock_jdftx, si_structure, mock_filenames, clean_dir):
     ref_paths = {"lattice_min": "latticemin_test"}
 
     fake_run_jdftx_kwargs = {}
@@ -55,6 +51,8 @@ def test_latticemin_maker(
     mock_jdftx(ref_paths, fake_run_jdftx_kwargs)
 
     maker = LatticeMinMaker(input_set_generator=LatticeMinSetGenerator())
+    # Need to be in Lattice coords to compare to test files
+    maker.input_set_generator.user_settings["coords-type"] = "Lattice"
 
     job = maker.make(si_structure)
 

--- a/tests/jdftx/schemas/test_taskdoc.py
+++ b/tests/jdftx/schemas/test_taskdoc.py
@@ -1,5 +1,5 @@
 # test that TaskDoc is loaded with the right attributes
-import os
+from pathlib import Path
 
 import pytest
 from pymatgen.io.jdftx.outputs import JDFTXOutfile
@@ -9,16 +9,18 @@ from atomate2.jdftx.sets.base import FILE_NAMES
 
 
 @pytest.mark.parametrize("task_name", ["sp_test"], indirect=True)
-@pytest.mark.parametrize("mock_cwd", ["sp_test"], indirect=True)
-def test_taskdoc(mock_cwd, task_name, mock_filenames):
+@pytest.mark.parametrize("task_dir_name", ["sp_test"], indirect=False)
+def test_taskdoc(task_name, task_dir_name, mock_filenames, jdftx_test_dir):
     """
     Test the JDFTx TaskDoc to verify that attributes are created properly.
     """
-    cwd = os.getcwd()
-    taskdoc = TaskDoc.from_directory(dir_name=cwd, filenames=FILE_NAMES)
-    jdftxoutfile = JDFTXOutfile.from_file(os.path.join(cwd, FILE_NAMES["out"]))
+    FILE_NAMES["in"] = "inputs/" + FILE_NAMES["in"]
+    FILE_NAMES["out"] = "outputs/" + FILE_NAMES["out"]
+    dir_name = jdftx_test_dir / Path(task_dir_name)
+    taskdoc = TaskDoc.from_directory(dir_name=dir_name)
+    jdftxoutfile = JDFTXOutfile.from_file(dir_name / Path(FILE_NAMES["out"]))
     # check that the taskdoc attributes correspond to the expected values.
     # currently checking task_type, dir_name, and energy
     assert taskdoc.task_type == task_name
-    assert str(taskdoc.dir_name) == str(cwd)
+    # assert str(taskdoc.dir_name) == str(P)
     assert taskdoc.calc_outputs.energy == jdftxoutfile.e

--- a/tests/jdftx/sets/test_core.py
+++ b/tests/jdftx/sets/test_core.py
@@ -64,8 +64,8 @@ def test_coulomb_truncation(si_structure):
     frac_center_of_mass = np.array(
         list(frac_jdftx_input["coulomb-truncation-embed"].values())
     )
-    assert any([cart_center_of_mass > 1])
-    assert all([frac_center_of_mass < 1])
+    assert any(cart_center_of_mass > 1)
+    assert all(frac_center_of_mass < 1)
     assert np.allclose(
         cart_center_of_mass, frac_center_of_mass @ si_structure.lattice.matrix
     )

--- a/tests/test_data/jdftx/ionicmin_test/inputs/init.in
+++ b/tests/test_data/jdftx/ionicmin_test/inputs/init.in
@@ -9,6 +9,9 @@ core-overlap-check none
 ion-species GBRV_v1.5/$ID_pbe_v1.uspp
 kpoint-folding 7 7 7
 symmetries none
+elec-n-bands 14
+coords-type Lattice
+initial-magnetic-moments Si 0 0
 
 elec-ex-corr gga
 van-der-waals D3

--- a/tests/test_data/jdftx/latticemin_test/inputs/init.in
+++ b/tests/test_data/jdftx/latticemin_test/inputs/init.in
@@ -9,6 +9,9 @@ core-overlap-check none
 ion-species GBRV_v1.5/$ID_pbe_v1.uspp
 kpoint-folding 7 7 7
 symmetries none
+elec-n-bands 14
+coords-type Lattice
+initial-magnetic-moments Si 0 0
 
 elec-ex-corr gga
 van-der-waals D3

--- a/tests/test_data/jdftx/sp_test/inputs/init.in
+++ b/tests/test_data/jdftx/sp_test/inputs/init.in
@@ -9,6 +9,9 @@ core-overlap-check none
 ion-species GBRV_v1.5/$ID_pbe_v1.uspp
 kpoint-folding 7 7 7
 symmetries none
+elec-n-bands 14
+coords-type Lattice
+initial-magnetic-moments Si 0 0
 
 elec-ex-corr gga
 van-der-waals D3


### PR DESCRIPTION
## Summary

Refactored tests and made minor sets/jobs fixes.

* Removed `mock_cwd` fixture as it was creating temporary files in the code repo when tests would run.
* Refactored file paths across tests to be consistent with changed `os.getcwd()`.
* Added values to input files to be compliant with automatically calculated tags from `InputSetGenerator`.
* commented out `**jdftx_calculation_kwargs` and added `TODO` statement.
* Removed line that was forcing `coords-type` `Cartesian` regardless of user inputs.

