### PR TITLE
Changing core sets and TaskDoc

### DIFF
--- a/src/atomate2/jdftx/schemas/task.py
+++ b/src/atomate2/jdftx/schemas/task.py
@@ -9,7 +9,6 @@ from typing import Any, Optional, Self, TypeVar, Union
 from custodian.jdftx.jobs import JDFTxJob  # Waiting on Sophie's PR
 from emmet.core.structure import StructureMetadata
 from pydantic import BaseModel, Field
-from pymatgen.core import Structure
 
 from atomate2.jdftx.schemas.calculation import (
     Calculation,
@@ -60,7 +59,6 @@ class TaskDoc(StructureMetadata):
     calc_inputs: Optional[CalculationInput] = Field(
         {}, description="JDFTx calculation inputs"
     )
-    structure: Structure = Field(None, description="Final output structure")
     run_stats: Optional[dict[str, RunStatistics]] = Field(
         None,
         description="Summary of runtime statistics for each calculation in this task",

--- a/src/atomate2/jdftx/sets/core.py
+++ b/src/atomate2/jdftx/sets/core.py
@@ -17,11 +17,6 @@ class SinglePointSetGenerator(JdftxInputGenerator):
     default_settings: dict = field(
         default_factory=lambda: {
             **_BASE_JDFTX_SET,
-            "fluid": {"type": "LinearPCM"},
-            "pcm-variant": "CANDLE",
-            "fluid-solvent": {"name": "H2O"},
-            "fluid-cation": {"name": "Na+", "concentration": 0.5},
-            "fluid-anion": {"name": "F-", "concentration": 0.5},
         }
     )
 
@@ -33,11 +28,6 @@ class IonicMinSetGenerator(JdftxInputGenerator):
     default_settings: dict = field(
         default_factory=lambda: {
             **_BASE_JDFTX_SET,
-            "fluid": {"type": "LinearPCM"},
-            "pcm-variant": "CANDLE",
-            "fluid-solvent": {"name": "H2O"},
-            "fluid-cation": {"name": "Na+", "concentration": 0.5},
-            "fluid-anion": {"name": "F-", "concentration": 0.5},
             "ionic-minimize": {"nIterations": 100},
         }
     )
@@ -50,12 +40,23 @@ class LatticeMinSetGenerator(JdftxInputGenerator):
     default_settings: dict = field(
         default_factory=lambda: {
             **_BASE_JDFTX_SET,
+            "lattice-minimize": {"nIterations": 100},
+            "latt-move-scale": {"s0": 1, "s1": 1, "s2": 1},
+        }
+    )
+
+
+class BEASTSetGenerator(JdftxInputGenerator):
+    """Generate BEAST Database ionic relaxation set."""
+
+    default_settings: dict = field(
+        default_factory=lambda: {
+            **_BASE_JDFTX_SET,
             "fluid": {"type": "LinearPCM"},
             "pcm-variant": "CANDLE",
             "fluid-solvent": {"name": "H2O"},
             "fluid-cation": {"name": "Na+", "concentration": 0.5},
             "fluid-anion": {"name": "F-", "concentration": 0.5},
-            "lattice-minimize": {"nIterations": 100},
-            "latt-move-scale": {"s0": 1, "s1": 1, "s2": 1},
+            "ionic-minimize": {"nIterations": 100},
         }
     )

--- a/tests/jdftx/schemas/test_taskdoc.py
+++ b/tests/jdftx/schemas/test_taskdoc.py
@@ -20,7 +20,6 @@ def test_taskdoc(task_name, task_dir_name, mock_filenames, jdftx_test_dir):
     taskdoc = TaskDoc.from_directory(dir_name=dir_name)
     jdftxoutfile = JDFTXOutfile.from_file(dir_name / Path(FILE_NAMES["out"]))
     # check that the taskdoc attributes correspond to the expected values.
-    # currently checking task_type, dir_name, and energy
+    # currently checking task_type and energy
     assert taskdoc.task_type == task_name
-    # assert str(taskdoc.dir_name) == str(P)
     assert taskdoc.calc_outputs.energy == jdftxoutfile.e

--- a/tests/test_data/jdftx/ionicmin_test/inputs/init.in
+++ b/tests/test_data/jdftx/ionicmin_test/inputs/init.in
@@ -30,12 +30,6 @@ electronic-minimize \
     nIterations 100 \
     energyDiffThreshold 1e-07
 
-fluid LinearPCM
-fluid-solvent H2O
-fluid-anion F- 0.5
-fluid-cation Na+ 0.5
-pcm-variant CANDLE
-
 dump-name jdftx.$VAR
 band-projection-params yes no
 dump End Dtot State BandEigs BandProjections BoundCharge DOS Ecomponents EigStats ElecDensity Forces KEdensity VfluidTot

--- a/tests/test_data/jdftx/latticemin_test/inputs/init.in
+++ b/tests/test_data/jdftx/latticemin_test/inputs/init.in
@@ -28,11 +28,6 @@ electronic-minimize \
     nIterations 100 \
     energyDiffThreshold 1e-07
 
-fluid LinearPCM
-fluid-solvent H2O
-fluid-anion F- 0.5
-fluid-cation Na+ 0.5
-pcm-variant CANDLE
 
 dump-name jdftx.$VAR
 band-projection-params yes no

--- a/tests/test_data/jdftx/sp_test/inputs/init.in
+++ b/tests/test_data/jdftx/sp_test/inputs/init.in
@@ -28,12 +28,6 @@ electronic-minimize \
     nIterations 100 \
     energyDiffThreshold 1e-07
 
-fluid LinearPCM
-fluid-solvent H2O
-fluid-anion F- 0.5
-fluid-cation Na+ 0.5
-pcm-variant CANDLE
-
 dump-name jdftx.$VAR
 band-projection-params yes no
 dump End Dtot State BandEigs BandProjections BoundCharge DOS Ecomponents EigStats ElecDensity Forces KEdensity VfluidTot


### PR DESCRIPTION
## Summary

Two main changes were made. First, the core input sets were changed to be vacuum by default and a `BEASTSetGenerator` was added with default fluid settings. Second, the `TaskDoc` was fixed to remove the `structure` attribute of the main `TaskDoc` and the`CalculationOutput` schema now returns a pymatgen `Structure` instead of a `JOutStructure`.
